### PR TITLE
Fix distribute function filtering viable parties on every iteration of the loop.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93,7 +93,7 @@ var rebalancePartyListMember = function (_a) {
     var result = parties.map(function (p) {
         var tempPartyListMemberCount = new bignumber_js_1.default(p.partyListMemberCount);
         var partyListMemberCount = tempPartyListMemberCount
-            .multipliedBy(exports.REP_LIMIT)
+            .multipliedBy(exports.PARTY_LIST_LIMIT)
             .dividedBy(new bignumber_js_1.default(totalPartyListMember))
             .integerValue(bignumber_js_1.default.ROUND_FLOOR)
             .toNumber();
@@ -132,16 +132,20 @@ var distributeRemainingSeats = function (_a, originalIds) {
     var index = 0;
     var viableParties = clonedParties;
     while (newRemainingPartyListSeat > 0 && viableParties.length > 0) {
-        viableParties = viableParties.filter(function (p) {
-            return p.isViableForPartyList() &&
-                p.partyListCandidateCount > p.partyListMemberCount;
-        });
+        if (index === 0) {
+            viableParties = viableParties.filter(function (p) {
+                return p.isViableForPartyList() &&
+                    p.partyListCandidateCount > p.partyListMemberCount;
+            });
+        }
         var viablePartiesIndex = index % viableParties.length;
         var viableParty = viableParties[viablePartiesIndex];
         viableParty.partyListMemberCount += 1;
         index += 1;
         newRemainingPartyListSeat -= 1;
         newTotalPartyListMember += 1;
+        if (index === viableParties.length)
+            index = 0;
     }
     var sortedParties = originalIds.map(function (id) { return clonedParties.filter(function (party) { return party.id === id; })[0]; });
     return {

--- a/dist/index.spec.js
+++ b/dist/index.spec.js
@@ -44,6 +44,42 @@ var partyG = new index_1.Party({
     voteCount: 1000,
     partyListCandidateCount: 150,
 });
+var partyH = new index_1.Party({
+    id: '7',
+    electedMemberCount: 31,
+    voteCount: 1040,
+    partyListCandidateCount: 40,
+});
+var partyI = new index_1.Party({
+    id: '8',
+    electedMemberCount: 15,
+    voteCount: 700,
+    partyListCandidateCount: 34,
+});
+var partyJ = new index_1.Party({
+    id: '9',
+    electedMemberCount: 38,
+    voteCount: 900,
+    partyListCandidateCount: 150,
+});
+var partyK = new index_1.Party({
+    id: '10',
+    electedMemberCount: 34,
+    voteCount: 870,
+    partyListCandidateCount: 128,
+});
+var partyL = new index_1.Party({
+    id: '11',
+    electedMemberCount: 166,
+    voteCount: 2750,
+    partyListCandidateCount: 149,
+});
+var partyM = new index_1.Party({
+    id: '12',
+    electedMemberCount: 66,
+    voteCount: 920,
+    partyListCandidateCount: 101,
+});
 describe('Thailand Election Party List Calculation', function () {
     it('should pass monopoly case', function () {
         var parties = index_1.calculatePartyList([partyA]);
@@ -79,5 +115,15 @@ describe('Thailand Election Party List Calculation', function () {
         assert.equal(parties.length, 2);
         assert.equal(parties[0].partyListMemberCount, 0);
         assert.equal(parties[1].partyListMemberCount, 150);
+    });
+    it('should distribute seat to party having greatest remaining and candidate available', function () {
+        var parties = index_1.calculatePartyList([partyH, partyI, partyJ, partyK, partyL, partyM]);
+        assert.equal(parties.length, 6);
+        assert.equal(parties[0].partyListMemberCount, 40);
+        assert.equal(parties[1].partyListMemberCount, 34);
+        assert.equal(parties[2].partyListMemberCount, 25);
+        assert.equal(parties[3].partyListMemberCount, 26);
+        assert.equal(parties[4].partyListMemberCount, 25);
+        assert.equal(parties[5].partyListMemberCount, 0);
     });
 });

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -43,6 +43,42 @@ const partyG = new Party({
   voteCount: 1000,
   partyListCandidateCount: 150,
 })
+const partyH = new Party({
+  id: '7',
+  electedMemberCount: 31,
+  voteCount: 1040,
+  partyListCandidateCount: 40,
+})
+const partyI = new Party({
+  id: '8',
+  electedMemberCount: 15,
+  voteCount: 700,
+  partyListCandidateCount: 34,
+})
+const partyJ = new Party({
+  id: '9',
+  electedMemberCount: 38,
+  voteCount: 900,
+  partyListCandidateCount: 150,
+})
+const partyK = new Party({
+  id: '10',
+  electedMemberCount: 34,
+  voteCount: 870,
+  partyListCandidateCount: 128,
+})
+const partyL = new Party({
+  id: '11',
+  electedMemberCount: 166,
+  voteCount: 2750,
+  partyListCandidateCount: 149,
+})
+const partyM = new Party({
+  id: '12',
+  electedMemberCount: 66,
+  voteCount: 920,
+  partyListCandidateCount: 101,
+})
 
 describe('Thailand Election Party List Calculation', () => {
   it('should pass monopoly case', () => {
@@ -79,5 +115,15 @@ describe('Thailand Election Party List Calculation', () => {
     assert.equal(parties.length, 2)
     assert.equal(parties[0].partyListMemberCount, 0)
     assert.equal(parties[1].partyListMemberCount, 150)
+  })
+  it('should distribute seat to party having greatest remaining and candidate available', () => {
+    const parties = calculatePartyList([partyH, partyI, partyJ, partyK, partyL, partyM])
+    assert.equal(parties.length, 6)
+    assert.equal(parties[0].partyListMemberCount, 40)
+    assert.equal(parties[1].partyListMemberCount, 34)
+    assert.equal(parties[2].partyListMemberCount, 25)
+    assert.equal(parties[3].partyListMemberCount, 26)
+    assert.equal(parties[4].partyListMemberCount, 25)
+    assert.equal(parties[5].partyListMemberCount, 0)
   })
 })

--- a/index.ts
+++ b/index.ts
@@ -177,17 +177,20 @@ const distributeRemainingSeats = (
   let index = 0
   let viableParties = clonedParties
   while (newRemainingPartyListSeat > 0 && viableParties.length > 0) {
-    viableParties = viableParties.filter(
-      p =>
-        p.isViableForPartyList() &&
-        p.partyListCandidateCount > p.partyListMemberCount
-    )
+    if (index === 0) {
+      viableParties = viableParties.filter(
+        p =>
+          p.isViableForPartyList() &&
+          p.partyListCandidateCount > p.partyListMemberCount
+      )
+    }
     const viablePartiesIndex = index % viableParties.length
     const viableParty = viableParties[viablePartiesIndex]
     viableParty.partyListMemberCount += 1
     index += 1
     newRemainingPartyListSeat -= 1
     newTotalPartyListMember += 1
+    if (index === viableParties.length) index = 0
   }
   const sortedParties = originalIds.map(
     id => clonedParties.filter(party => party.id === id)[0]

--- a/index.ts
+++ b/index.ts
@@ -134,7 +134,7 @@ const rebalancePartyListMember = ({
       p.partyListMemberCount as number
     )
     const partyListMemberCount = tempPartyListMemberCount
-      .multipliedBy(REP_LIMIT)
+      .multipliedBy(PARTY_LIST_LIMIT)
       .dividedBy(new BigNumber(totalPartyListMember))
       .integerValue(BigNumber.ROUND_FLOOR)
       .toNumber()


### PR DESCRIPTION
Fix a bug revealed by a test case from #1.

The function `distributeRemainingSeats` shouldn't filter in every iteration of the loop, instead, it should trigger filter only when the seats got distributed to all the viable parties.